### PR TITLE
Add GPT-powered summarization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
 # crawl-and-summary
+
+This small project provides a simple script that fetches a web page and prints a short summary of its content. It also includes a lightweight web service with a React UI.
+
+## Requirements
+
+The crawler is implemented with the Python standard library. Summarization uses the OpenAI API, so you'll need an API key and the `openai` package installed. The optional web service also requires the `Flask` package.
+
+Install the dependencies with:
+
+```bash
+pip install openai Flask
+```
+
+## Usage
+
+```bash
+python crawl_and_summarize.py <URL>
+```
+
+Set the `OPENAI_API_KEY` environment variable before running the script so it can
+use the OpenAI API for summarization:
+
+```bash
+export OPENAI_API_KEY=your-key-here
+```
+
+The script downloads the specified URL, extracts text from the title and paragraphs, and prints the first few sentences. A browser-like `User-Agent` header is sent to avoid simple blocks.
+
+> **Note**: Internet access is required for the script to fetch external pages. On systems without internet connectivity the script will fail to retrieve the content.
+
+## Web service
+
+Run `app.py` to start a small web server with a React interface:
+
+```bash
+python app.py
+```
+
+Open [http://localhost:5000](http://localhost:5000) in your browser and enter a URL to generate a summary.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,23 @@
+from flask import Flask, request, jsonify
+from crawl_and_summarize import summarize_url
+
+app = Flask(__name__, static_folder="static", static_url_path="")
+
+@app.route('/api/summarize', methods=['POST'])
+def api_summarize():
+    data = request.get_json(force=True)
+    url = data.get('url')
+    if not url:
+        return jsonify({'error': 'URL is required'}), 400
+    try:
+        summary = summarize_url(url)
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+    return jsonify({'summary': summary})
+
+@app.route('/')
+def index():
+    return app.send_static_file('index.html')
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/crawl_and_summarize.py
+++ b/crawl_and_summarize.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+import sys
+import urllib.request
+import re
+import os
+from html.parser import HTMLParser
+
+
+class ParagraphParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.record = False
+        self.text_parts = []
+
+    def handle_starttag(self, tag, attrs):
+        if tag.lower() in {"p", "title", "h1", "h2"}:
+            self.record = True
+
+    def handle_endtag(self, tag):
+        if tag.lower() in {"p", "title", "h1", "h2"} and self.record:
+            self.record = False
+            self.text_parts.append("\n")
+
+    def handle_data(self, data):
+        if self.record:
+            cleaned = data.strip()
+            if cleaned:
+                self.text_parts.append(cleaned + " ")
+
+
+def fetch_url(url: str) -> str:
+    """Retrieve the URL and return its body as text."""
+    req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+    with urllib.request.urlopen(req) as response:
+        charset = response.headers.get_content_charset() or "utf-8"
+        return response.read().decode(charset, errors="replace")
+
+
+def clean_html(html: str) -> str:
+    """Remove scripts/styles and collapse whitespace."""
+    html = re.sub(r"<script.*?>.*?</script>", "", html, flags=re.DOTALL | re.IGNORECASE)
+    html = re.sub(r"<style.*?>.*?</style>", "", html, flags=re.DOTALL | re.IGNORECASE)
+    html = re.sub(r"\s+", " ", html)
+    return html
+
+
+def extract_text(html: str) -> str:
+    parser = ParagraphParser()
+    parser.feed(html)
+    return "".join(parser.text_parts)
+
+
+def summarize(text: str, sentences: int = 3) -> str:
+    """Summarize text using OpenAI. Falls back to simple summary on failure."""
+    try:
+        import openai  # type: ignore
+    except Exception:
+        openai = None
+
+    if openai:
+        api_key = os.getenv("OPENAI_API_KEY")
+        if api_key:
+            openai.api_key = api_key
+            prompt = (
+                f"Summarize the following text in {sentences} sentences:\n\n{text}"
+            )
+            try:
+                resp = openai.ChatCompletion.create(
+                    model="gpt-3.5-turbo",
+                    messages=[
+                        {
+                            "role": "system",
+                            "content": "You are a helpful assistant that summarizes text.",
+                        },
+                        {"role": "user", "content": prompt},
+                    ],
+                    max_tokens=256,
+                    temperature=0.5,
+                )
+                return resp.choices[0].message.content.strip()
+            except Exception:
+                pass
+
+    # Fallback basic summarization
+    sentence_list = re.split(r"(?<=[.!?])\s+", text)
+    return " ".join(sentence_list[:sentences]).strip()
+
+
+def summarize_url(url: str, sentences: int = 3) -> str:
+    """Fetch the URL and return a short summary."""
+    try:
+        html = fetch_url(url)
+    except Exception as exc:
+        return f"Failed to fetch URL: {exc}"
+    cleaned = clean_html(html)
+    text = extract_text(cleaned)
+    if not text:
+        return "No text found on the page."
+    return summarize(text, sentences)
+
+
+def main(url: str):
+    summary = summarize_url(url)
+    print(summary)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python crawl_and_summarize.py <URL>")
+        sys.exit(1)
+    main(sys.argv[1])

--- a/sample.html
+++ b/sample.html
@@ -1,0 +1,4 @@
+<html><body>
+<p>Hello world. This is a test page.</p>
+<p>It has multiple paragraphs to summarize.</p>
+</body></html>

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>Crawl and Summarize</title>
+  <script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+  <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  <style>
+    body { font-family: Arial, sans-serif; padding: 2rem; }
+    input { width: 100%; padding: 0.5rem; margin-bottom: 1rem; }
+    button { padding: 0.5rem 1rem; }
+    pre { white-space: pre-wrap; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel">
+function App() {
+  const [url, setUrl] = React.useState('');
+  const [summary, setSummary] = React.useState('');
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState(null);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    setSummary('');
+    try {
+      const resp = await fetch('/api/summarize', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({url}),
+      });
+      const data = await resp.json();
+      if (!resp.ok) {
+        throw new Error(data.error || 'Failed to summarize');
+      }
+      setSummary(data.summary);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div>
+      <h1>Crawl and Summarize</h1>
+      <form onSubmit={handleSubmit}>
+        <input
+          type="text"
+          placeholder="Enter URL..."
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+        />
+        <button type="submit" disabled={loading}>Summarize</button>
+      </form>
+      {error && <p style={{color:'red'}}>{error}</p>}
+      {summary && <pre>{summary}</pre>}
+    </div>
+  );
+}
+
+ReactDOM.render(<App />, document.getElementById('root'));
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- support GPT-based summarization with `OPENAI_API_KEY`
- document installing `openai` and setting API key in README

## Testing
- `python -m py_compile crawl_and_summarize.py app.py`
- `python crawl_and_summarize.py file://$PWD/sample.html`
- `python app.py` *(fails: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684101cb9aa4832e818f4af11d8a8d21